### PR TITLE
Improve template tests

### DIFF
--- a/TextTemplate.Tests/UnitTest1.cs
+++ b/TextTemplate.Tests/UnitTest1.cs
@@ -46,7 +46,18 @@ Josie";
         }
 
         var outText = sb.ToString();
-        Assert.NotEmpty(outText);
+        const string expected = "Dear Aunt Mildred,\n\n" +
+            "It was a pleasure to see you at the wedding.\n\n" +
+            "Thank you for the lovely bone china tea set.\n\n" +
+            "Best wishes,\nJosie\n" +
+            "Dear Uncle John,\n\n" +
+            "It is a shame you couldn't make it to the wedding.\n\n" +
+            "Thank you for the lovely moleskin pants.\n\n" +
+            "Best wishes,\nJosie\n" +
+            "Dear Cousin Rodney,\n\n" +
+            "It is a shame you couldn't make it to the wedding.\n\n" +
+            "Best wishes,\nJosie\n";
+        Assert.Equal(expected, outText);
     }
 
     [Fact(Skip="Block parsing not fully implemented")]

--- a/TextTemplate/Template.cs
+++ b/TextTemplate/Template.cs
@@ -394,6 +394,8 @@ internal static class Evaluator
     {
         if (data == null) return null;
         if (field == ".") return data;
+        if (field.StartsWith('.'))
+            field = field[1..];
         if (data is IDictionary dict)
         {
             if (dict.Contains(field)) return dict[field];


### PR DESCRIPTION
## Summary
- fix property resolution when expression starts with `.`
- verify example template output exactly

## Testing
- `dotnet test TextTemplate.Tests/TextTemplate.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68482f0c9f70832f9d3f29f9870b90a8