### PR TITLE
Implement whitespace trimming and update tests

### DIFF
--- a/TextTemplate.Tests/UnitTest1.cs
+++ b/TextTemplate.Tests/UnitTest1.cs
@@ -47,11 +47,11 @@ Josie";
 
         var outText = sb.ToString();
         const string expected = "Dear Aunt Mildred,\n\n" +
-            "It was a pleasure to see you at the wedding.\n\n" +
+            "It was a pleasure to see you at the wedding.\n" +
             "Thank you for the lovely bone china tea set.\n\n" +
             "Best wishes,\nJosie\n" +
             "Dear Uncle John,\n\n" +
-            "It is a shame you couldn't make it to the wedding.\n\n" +
+            "It is a shame you couldn't make it to the wedding.\n" +
             "Thank you for the lovely moleskin pants.\n\n" +
             "Best wishes,\nJosie\n" +
             "Dear Cousin Rodney,\n\n" +


### PR DESCRIPTION
## Summary
- handle `{{-` and `-}}` whitespace trimming in Tokenize
- adjust ExampleTemplate test expectations to match official Go behaviour

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6848356c5530832f8c0e60724ad4033a