### PR TITLE
Add delimiter, comments and pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ See if Codex can port Go's template package to C#:
 
 - https://pkg.go.dev/text/template#pkg-overview
 - https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/text/template/template.go
+
+This repository contains an experimental C# port with basic functionality. It
+now supports:
+
+- Custom delimiters via `Delims`.
+- Template comments using `{{/* comment */}}`.
+- A small set of built-in functions (`join`, `println`, `len`, `upper`, `lower`,
+  `index`).
+- Simple pipeline expressions (`{{ .Name | upper }}`).


### PR DESCRIPTION
## Summary
- support custom delimiters on templates
- ignore `{{/* */}}` comments in templates
- implement basic pipeline evaluation
- expose `len`, `upper`, `lower` and `index` builtin funcs
- document new features in README

## Testing
- `dotnet test TextTemplate.Tests/TextTemplate.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68483dbaf2a8832f8031bb651a79164c