### PR TITLE
Add simple ANTLR parsing test

### DIFF
--- a/TextTemplate.Tests/UnitTest1.cs
+++ b/TextTemplate.Tests/UnitTest1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using TextTemplate;
+using Antlr4.Runtime;
 
 namespace TextTemplate.Tests;
 
@@ -83,5 +84,17 @@ Josie";
         Assert.Equal(masterOut, fileOut);
         Assert.NotEmpty(masterOut);
         Assert.NotEmpty(overlayOut);
+    }
+
+    [Fact]
+    public void AntlrParser_ParsesPlainText()
+    {
+        const string text = "Hello world";
+        var input = new AntlrInputStream(text);
+        var lexer = new GoTemplateLexer(input);
+        var tokens = new CommonTokenStream(lexer);
+        var parser = new GoTemplateParser(tokens);
+        parser.template();
+        Assert.Equal(0, parser.NumberOfSyntaxErrors);
     }
 }


### PR DESCRIPTION
## Summary
- demonstrate ANTLR parser usage by parsing plain text

## Testing
- `dotnet test -noconsolelogger` *(fails: TerminalLogger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68485df66d9c832fa6b3a8a2a17187ea