### PR TITLE
Fix GoTemplate grammar

### DIFF
--- a/TextTemplate/GoTemplate.g4
+++ b/TextTemplate/GoTemplate.g4
@@ -34,10 +34,13 @@ command
     ;
 
 operand
+    : primary ('.' IDENTIFIER '(' (pipeline (',' pipeline)*)? ')')*
+    ;
+
+primary
     : IDENTIFIER
     | chainedField
     | variable
-    | methodCall
     | functionCall
     | literal
     | '(' pipeline ')'
@@ -51,9 +54,6 @@ variable
     : '$' IDENTIFIER
     ;
 
-methodCall
-    : operand '.' IDENTIFIER '(' (pipeline (',' pipeline)*)? ')'
-    ;
 
 functionCall
     : IDENTIFIER '(' (pipeline (',' pipeline)*)? ')'
@@ -78,7 +78,7 @@ RIGHT_DELIM
 STRING
     : '"' (~["\r\n] | '\\"')* '"'
     | '`' (~[`])* '`'
-    | '\'' (~['\r\n] | '\\'\'')* '\''
+    | '\'' ( '\\' . | ~['\r\n] )* '\''
     ;
 
 NUMBER


### PR DESCRIPTION
## Summary
- fix the STRING lexer rule
- remove mutual left recursion between `operand` and `methodCall`

## Testing
- `dotnet build TextTemplate/TextTemplate.csproj -v minimal` *(fails: GetJava task requires OS detection)*
- `antlr4 -Dlanguage=CSharp TextTemplate/GoTemplate.g4`

------
https://chatgpt.com/codex/tasks/task_e_68486624fa68832f8af9f34180c9f1a2