### PR TITLE
Improve grammar tests

### DIFF
--- a/TextTemplate.Tests/UnitTest1.cs
+++ b/TextTemplate.Tests/UnitTest1.cs
@@ -94,8 +94,27 @@ Josie";
         var lexer = new GoTemplateLexer(input);
         var tokens = new CommonTokenStream(lexer);
         var parser = new GoTemplateParser(tokens);
-        parser.template();
+        var tree = parser.template();
         Assert.Equal(0, parser.NumberOfSyntaxErrors);
+        Assert.Equal("(template (element Hello world))", tree.ToStringTree(parser));
+    }
+
+    [Fact]
+    public void AntlrLexer_TokenizesAction()
+    {
+        const string text = "Hello {{.Name}}!";
+        var input = new AntlrInputStream(text);
+        var lexer = new GoTemplateLexer(input);
+        var tokens = new List<IToken>();
+        IToken t;
+        while ((t = lexer.NextToken()).Type != TokenConstants.EOF)
+            tokens.Add(t);
+
+        Assert.Collection(tokens,
+            tok => Assert.Equal(GoTemplateLexer.TEXT, tok.Type),
+            tok => Assert.Equal(GoTemplateLexer.LEFT_DELIM, tok.Type),
+            tok => Assert.Equal(GoTemplateLexer.TEXT, tok.Type)
+        );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add parser tree validation to plain text test
- add lexer tokenization test for action syntax

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6849324f2e64832fbe85a81a7090a4c7