### PR TITLE
Implement break/continue for range loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ now supports:
 - Custom delimiters via `Delims`.
 - Template comments using `{{/* comment */}}`.
 - A small set of built-in functions (`join`, `println`, `len`, `upper`, `lower`,
-  `index`).
+  `index`, `eq`).
 - Simple pipeline expressions (`{{ .Name | upper }}`).
+- Basic loop control with `{{break}}` and `{{continue}}` inside `range`.

--- a/TextTemplate.Tests/BreakContinueTests.cs
+++ b/TextTemplate.Tests/BreakContinueTests.cs
@@ -1,0 +1,26 @@
+using TextTemplate;
+using Xunit;
+
+namespace TextTemplate.Tests;
+
+public class BreakContinueTests
+{
+    [Fact]
+    public void RangeSupportsBreak()
+    {
+        var tpl = Template.New("t").Parse("{{range .}}{{.}}{{break}}{{end}}");
+        var data = new[] {"a","b","c"};
+        var outText = tpl.Execute(data);
+        Assert.Equal("a", outText);
+    }
+
+    [Fact]
+    public void RangeSupportsContinue()
+    {
+        var tpl = Template.New("t").Parse("{{range .}}{{continue}}{{.}}{{end}}");
+        var data = new[] {"a","b","c"};
+        var outText = tpl.Execute(data);
+        Assert.Equal(string.Empty, outText);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `eq` helper to built‑in function map
- implement `break` and `continue` nodes and hook them into parser
- enhance `RangeNode` to handle break/continue during execution
- test break and continue functionality
- document new features in README

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68493abebfd8832fa3edaafd4b0e6ca7