### PR TITLE
Rename AntlrTemplate and support object input

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ See if Codex can port Go's template package to C#:
 - https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/text/template/template.go
 
 This repository now only includes a minimal example. The
-`AntlrTemplate.Process` helper performs simple variable substitution by
+`TemplateEngine.Process` helper performs simple variable substitution by
 parsing templates with the `GoTemplateLexer` and `GoTemplateParser`.

--- a/tests/TextTemplate.Tests/FullTemplateFromFileTests.cs
+++ b/tests/TextTemplate.Tests/FullTemplateFromFileTests.cs
@@ -17,7 +17,7 @@ public class FullTemplateFromFileTests
         string template = File.ReadAllText(templatePath);
         string expected = File.ReadAllText(expectedPath);
 
-        var result = AntlrTemplate.Process(template, new Dictionary<string, object>
+        var result = TemplateEngine.Process(template, new Dictionary<string, object>
         {
             ["Name"] = "Bob",
             ["Gift"] = "toaster",

--- a/tests/TextTemplate.Tests/UnitTest1.cs
+++ b/tests/TextTemplate.Tests/UnitTest1.cs
@@ -19,7 +19,7 @@ public class UnitTest1
     public void Template_ReturnsPlainTextUnchanged()
     {
         const string text = "Hello world";
-        var result = AntlrTemplate.Process(text, new Dictionary<string, object>());
+        var result = TemplateEngine.Process(text, new Dictionary<string, object>());
         Assert.Equal("Hello world", result);
     }
 
@@ -27,7 +27,7 @@ public class UnitTest1
     public void Template_ReplacesVariable()
     {
         const string text = "Hello {{.Name}}!";
-        var result = AntlrTemplate.Process(text, new Dictionary<string, object>
+        var result = TemplateEngine.Process(text, new Dictionary<string, object>
         {
             ["Name"] = "World"
         });
@@ -39,7 +39,7 @@ public class UnitTest1
     public void AntlrTemplate_ReplacesMultipleVariables()
     {
         const string text = "Hello {{.Name}}, you brought a {{.Gift}}.";
-        var result = AntlrTemplate.Process(text, new Dictionary<string, object>
+        var result = TemplateEngine.Process(text, new Dictionary<string, object>
         {
             ["Name"] = "Alice",
             ["Gift"] = "book"
@@ -60,7 +60,7 @@ Thank you for the lovely {{ .Gift }}.
 Best wishes,
 Josie";
 
-        var result = AntlrTemplate.Process(letter, new Dictionary<string, object>
+        var result = TemplateEngine.Process(letter, new Dictionary<string, object>
         {
             ["Name"] = "Bob",
             ["Gift"] = "toaster",
@@ -80,7 +80,7 @@ Josie";
     public void AntlrTemplate_HandlesForLoop()
     {
         const string tmpl = "Numbers: {{ for n in Items }}{{ n }},{{ end }}";
-        var result = AntlrTemplate.Process(tmpl, new Dictionary<string, object>
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
         {
             ["Items"] = new[] { 1, 2, 3 }
         });
@@ -91,7 +91,7 @@ Josie";
     public void AntlrTemplate_NestedField()
     {
         const string tmpl = "User: {{ .User.Name }}";
-        var result = AntlrTemplate.Process(tmpl, new Dictionary<string, object>
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
         {
             ["User"] = new Recipient { Name = "John" }
         });
@@ -102,7 +102,7 @@ Josie";
     public void AntlrTemplate_ElseIfBlock()
     {
         const string tmpl = "{{ if .A }}A{{ else if .B }}B{{ else }}C{{ end }}";
-        var result = AntlrTemplate.Process(tmpl, new Dictionary<string, object>
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
         {
             ["A"] = false,
             ["B"] = true
@@ -114,10 +114,19 @@ Josie";
     public void AntlrTemplate_ForLoopElse()
     {
         const string tmpl = "{{ for x in Items }}X{{ else }}Empty{{ end }}";
-        var result = AntlrTemplate.Process(tmpl, new Dictionary<string, object>
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
         {
             ["Items"] = new int[0]
         });
         Assert.Equal("Empty", result);
+    }
+
+    [Fact]
+    public void TemplateEngine_UsesObjectProperties()
+    {
+        const string tmpl = "Hello {{ .Name }}!";
+        var model = new Recipient { Name = "World" };
+        var result = TemplateEngine.Process(tmpl, model);
+        Assert.Equal("Hello World!", result);
     }
 }


### PR DESCRIPTION
## Summary
- rename `AntlrTemplate` to `TemplateEngine`
- add `TemplateEngine.Process<T>` overload for using model objects
- adjust unit tests for the new name
- test using model properties
- update README to reference the new class

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6849cf3e67f4832fa0ff719e6d4688e3