### PR TITLE
Add comment syntax support

### DIFF
--- a/src/TextTemplate/TemplateEngine.cs
+++ b/src/TextTemplate/TemplateEngine.cs
@@ -20,6 +20,7 @@ public static class TemplateEngine
     public static string Process(string templateString, IDictionary<string, object> data)
     {
         templateString = PreprocessWhitespace(templateString);
+        templateString = PreprocessComments(templateString);
         AntlrInputStream inputStream = new(templateString);
         var lexer = new GoTextTemplateLexer(inputStream);
         var tokens = new CommonTokenStream(lexer);
@@ -68,6 +69,11 @@ public static class TemplateEngine
             i++;
         }
         return sb.ToString();
+    }
+
+    private static string PreprocessComments(string template)
+    {
+        return Regex.Replace(template, "\\{\\{-?\\s*/\\*.*?\\*/\\s*-?\\}\\}", string.Empty, RegexOptions.Singleline);
     }
 
     private static IDictionary<string, object> ToDictionary(object model)

--- a/tests/TextTemplate.Tests/UnitTest1.cs
+++ b/tests/TextTemplate.Tests/UnitTest1.cs
@@ -275,4 +275,20 @@ Josie";
         });
         Assert.Equal("Empty", result);
     }
+
+    [Fact]
+    public void AntlrTemplate_BasicComment()
+    {
+        const string tmpl = "Hello {{/* ignore */}}World";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>());
+        Assert.Equal("Hello World", result);
+    }
+
+    [Fact]
+    public void AntlrTemplate_TrimmedComment()
+    {
+        const string tmpl = "A {{-/* c */-}} B";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>());
+        Assert.Equal("AB", result);
+    }
 }


### PR DESCRIPTION
## Summary
- strip comment blocks before parsing templates
- test that comment blocks are ignored

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684a0882a9c0832fb015a12c29167efa