### PR TITLE
Support dynamic index paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ parsing templates with the `GoTemplateLexer` and `GoTemplateParser`.
 
 Supported built-in functions include `eq`, `ne`, numeric comparisons `lt`, `le`,
 `gt`, `ge`, logical operations `and`, `or` and negation `not`.
+
+Variable access supports nested fields, array indexing with variables,
+string keys using quotes, and safely returns empty strings for missing fields.

--- a/tests/TextTemplate.Tests/UnitTest1.cs
+++ b/tests/TextTemplate.Tests/UnitTest1.cs
@@ -211,6 +211,18 @@ Josie";
     }
 
     [Fact]
+    public void AntlrTemplate_ArrayIndexingVariable()
+    {
+        const string tmpl = "Current: {{ .Items[.CurrentIndex] }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
+        {
+            ["Items"] = new[] { "zero", "one", "two" },
+            ["CurrentIndex"] = 2
+        });
+        Assert.Equal("Current: two", result);
+    }
+
+    [Fact]
     public void AntlrTemplate_MapAccess()
     {
         const string tmpl = "Value: {{ .Data.key }}";
@@ -219,6 +231,17 @@ Josie";
             ["Data"] = new Dictionary<string, object> { ["key"] = "val" }
         });
         Assert.Equal("Value: val", result);
+    }
+
+    [Fact]
+    public void AntlrTemplate_MapAccessSpecialKey()
+    {
+        const string tmpl = "Val: {{ .Data[\"key-with-dashes\"] }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
+        {
+            ["Data"] = new Dictionary<string, object> { ["key-with-dashes"] = "x" }
+        });
+        Assert.Equal("Val: x", result);
     }
 
     [Fact]
@@ -282,6 +305,14 @@ Josie";
         const string tmpl = "Hello {{/* ignore */}}World";
         var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>());
         Assert.Equal("Hello World", result);
+    }
+
+    [Fact]
+    public void AntlrTemplate_MissingFieldAccess()
+    {
+        const string tmpl = "Missing: {{ .MaybeNil.Field }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>());
+        Assert.Equal("Missing: ", result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `PathReference` to parse dynamic indexes like `.Items[.Index]`
- support resolving indexes referencing other variables
- document advanced variable access
- test map access with quoted key, dynamic array index, and missing fields

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684a0dfd4548832fa31154ed4b3e95ab