### PR TITLE
Use root README for package docs

### DIFF
--- a/.github/workflows/build-test-nugetpush.yml
+++ b/.github/workflows/build-test-nugetpush.yml
@@ -6,8 +6,13 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.gitignore'
+      - '**/*.txt'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.gitignore'
+      - '**/*.txt'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # text/template
 
+[![NuGet](https://img.shields.io/nuget/v/go-text-template.svg)](https://www.nuget.org/packages/go-text-template/)
+
 This project is a C# adaptation of Go's template engine. It began as an
 experiment to see whether OpenAI Codex could port the Go implementation to
 .NET. Claude.AI helped with explanations and refinements along the way.

--- a/src/TextTemplate/TextTemplate.csproj
+++ b/src/TextTemplate/TextTemplate.csproj
@@ -8,10 +8,16 @@
     <Authors>Chris S.</Authors>
     <Description>A C# version of Go's text/template engine.</Description>
     <Version>1.0.0</Version>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/yetanotherchris/text-template</PackageProjectUrl>
     <RepositoryUrl>https://github.com/yetanotherchris/text-template</RepositoryUrl>
   </PropertyGroup>
+
+  <!-- Include README file in the NuGet package -->
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="" Link="README.md" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2" />


### PR DESCRIPTION
## Summary
- remove NuGet README file
- link the NuGet package to the main README

## Testing
- `dotnet test tests/TextTemplate.Tests/TextTemplate.Tests.csproj -v minimal`
- `dotnet pack src/TextTemplate/TextTemplate.csproj -c Release -o /tmp/nupkg`


------
https://chatgpt.com/codex/tasks/task_e_684ada7d75b4832fbfab80832875a3d5