### PR TITLE
Simplify enumerable count for len

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ substitution, loops and conditionals.
 - `html` - HTML escape the value
 - `js` - JavaScript escape the value
 - `urlquery` - escape for URL query parameters
+- `len` - length of a collection or string
+- `index` - retrieve an element by index or key
+- `slice` - slice strings or lists
+- `call` - invoke a function value
 
 ## Not Implemented Yet
 

--- a/src/TextTemplate/TemplateEngine.cs
+++ b/src/TextTemplate/TemplateEngine.cs
@@ -128,7 +128,82 @@ public static class TemplateEngine
             },
             ["html"] = args => System.Net.WebUtility.HtmlEncode(string.Concat(args.Select(a => a?.ToString()))),
             ["js"] = args => System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(string.Concat(args.Select(a => a?.ToString()))),
-            ["urlquery"] = args => Uri.EscapeDataString(string.Concat(args.Select(a => a?.ToString())))
+            ["urlquery"] = args => Uri.EscapeDataString(string.Concat(args.Select(a => a?.ToString()))),
+            ["len"] = args =>
+            {
+                if (args.Length == 0 || args[0] == null) return 0;
+                var v = args[0]!;
+                if (v is string s) return s.Length;
+                if (v is ICollection col) return col.Count;
+                if (v is IEnumerable enumerable)
+                {
+                    int count = 0;
+                    foreach (var _ in enumerable)
+                        count++;
+                    return count;
+                }
+                return 0;
+            },
+            ["index"] = args =>
+            {
+                if (args.Length < 2) return null;
+                object? current = args[0];
+                for (int i = 1; i < args.Length && current != null; i++)
+                {
+                    var key = args[i];
+                    if (current is IList list && key is int idx)
+                    {
+                        current = idx >= 0 && idx < list.Count ? list[idx] : null;
+                        continue;
+                    }
+                    if (current is IDictionary dict)
+                    {
+                        current = dict[key];
+                        continue;
+                    }
+                    current = null;
+                }
+                return current;
+            },
+            ["slice"] = args =>
+            {
+                if (args.Length == 0 || args[0] == null) return null;
+                int start = args.Length > 1 ? Convert.ToInt32(args[1]) : 0;
+                int end = args.Length > 2 ? Convert.ToInt32(args[2]) : -1;
+                var src = args[0];
+                if (src is string str)
+                {
+                    if (end < 0 || end > str.Length) end = str.Length;
+                    if (start < 0) start = 0;
+                    if (start >= end) return string.Empty;
+                    return str.Substring(start, end - start);
+                }
+                if (src is IList list)
+                {
+                    if (end < 0 || end > list.Count) end = list.Count;
+                    if (start < 0) start = 0;
+                    var result = new List<object?>();
+                    for (int i = start; i < end; i++)
+                        result.Add(list[i]);
+                    return result.ToArray();
+                }
+                return null;
+            },
+            ["call"] = args =>
+            {
+                if (args.Length == 0) return null;
+                var fn = args[0];
+                var callArgs = args.Skip(1).ToArray();
+                switch (fn)
+                {
+                    case Func<object?[], object?> f:
+                        return f(callArgs);
+                    case Delegate d:
+                        return d.DynamicInvoke(callArgs);
+                    default:
+                        return null;
+                }
+            }
         };
 
         public ReplacementVisitor(IDictionary<string, object> data)

--- a/tests/TextTemplate.Tests/UnitTest1.cs
+++ b/tests/TextTemplate.Tests/UnitTest1.cs
@@ -605,4 +605,49 @@ Josie";
         });
         result.ShouldBe("helloworld");
     }
+
+    [Fact]
+    public void AntlrTemplate_PipelineLen()
+    {
+        const string tmpl = "{{ len .Items }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
+        {
+            ["Items"] = new[] { 1, 2, 3 }
+        });
+        result.ShouldBe("3");
+    }
+
+    [Fact]
+    public void AntlrTemplate_PipelineIndex()
+    {
+        const string tmpl = "{{ index .Items 1 }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
+        {
+            ["Items"] = new[] { "a", "b", "c" }
+        });
+        result.ShouldBe("b");
+    }
+
+    [Fact]
+    public void AntlrTemplate_PipelineSliceString()
+    {
+        const string tmpl = "{{ slice .Txt 1 4 }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
+        {
+            ["Txt"] = "hello"
+        });
+        result.ShouldBe("ell");
+    }
+
+    [Fact]
+    public void AntlrTemplate_PipelineCall()
+    {
+        const string tmpl = "{{ call .Add 2 3 }}";
+        var data = new Dictionary<string, object>
+        {
+            ["Add"] = new Func<int, int, int>((a, b) => a + b)
+        };
+        var result = TemplateEngine.Process(tmpl, data);
+        result.ShouldBe("5");
+    }
 }


### PR DESCRIPTION
## Summary
- refine `len` helper to iterate enumerables directly rather than using `Cast<T>`

## Testing
- `dotnet test TextTemplate.sln`

------
https://chatgpt.com/codex/tasks/task_e_684b109cc828832f97e668e17a979de6