### PR TITLE
Add operations template file tests

### DIFF
--- a/tests/TextTemplate.Tests/OperationsFromFileTests.cs
+++ b/tests/TextTemplate.Tests/OperationsFromFileTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+using Shouldly;
+using TextTemplate;
+using System.Collections.Generic;
+using System.IO;
+
+namespace TextTemplate.Tests;
+
+public class OperationsFromFileTests
+{
+    [Fact]
+    public void AntlrTemplate_FileTemplate_Operations()
+    {
+        string baseDir = AppContext.BaseDirectory;
+        string templatePath = Path.Combine(baseDir, "TestData", "operations_template.txt");
+        string expectedPath = Path.Combine(baseDir, "TestData", "operations_expected.txt");
+
+        string template = File.ReadAllText(templatePath);
+        string expected = File.ReadAllText(expectedPath);
+
+        var result = TemplateEngine.Process(template, new Dictionary<string, object>
+        {
+            ["User"] = new Dictionary<string, object>
+            {
+                ["Name"] = "Alice",
+                ["IsActive"] = true,
+                ["HasPermission"] = true
+            },
+            ["DefaultValue"] = "",
+            ["UserValue"] = "Custom",
+            ["Status"] = "active",
+            ["Name"] = "Alice",
+            ["MessageCount"] = 5,
+            ["UserComment"] = "<b>Hello</b>",
+            ["SearchQuery"] = "foo bar&baz",
+            ["Items"] = new[] { "apple", "banana", "cherry" },
+            ["ItemCount"] = 3
+        });
+
+        result.ShouldBe(expected);
+    }
+}

--- a/tests/TextTemplate.Tests/TestData/operations_expected.txt
+++ b/tests/TextTemplate.Tests/TestData/operations_expected.txt
@@ -1,0 +1,11 @@
+Welcome, Alice!
+
+<span class="active">Online</span>
+Hello Alice, you have 5 messages
+&lt;b&gt;Hello&lt;/b&gt;
+foo%20bar%26baz
+0: apple
+1: banana
+2: cherry
+apple
+Small list: 3 items

--- a/tests/TextTemplate.Tests/TestData/operations_template.txt
+++ b/tests/TextTemplate.Tests/TestData/operations_template.txt
@@ -1,0 +1,29 @@
+{{if and .User.IsActive .User.HasPermission -}}
+  Welcome, {{.User.Name}}!
+{{end -}}
+{{if .DefaultValue -}}
+  {{.DefaultValue}}
+{{else -}}
+  {{.UserValue}}
+{{end -}}
+{{if eq .Status "active" -}}
+  <span class="active">Online</span>
+{{else if or eq .Status "away" eq .Status "busy" -}}
+  <span class="away">Not Available</span>
+{{end -}}
+{{printf "Hello %s, you have %d messages" .Name .MessageCount}}
+{{.UserComment | html}}
+{{.SearchQuery | urlquery}}
+{{range index, item := .Items -}}
+  {{printf "%d: %s" index item}}
+{{end -}}
+{{if gt .ItemCount 0 -}}
+  {{index .Items 0}}
+{{end -}}
+{{if and gt .ItemCount 0 le .ItemCount 10 -}}
+  Small list: {{printf "%d items" .ItemCount}}
+{{else if gt .ItemCount 10 -}}
+  Large list: {{printf "%d items" .ItemCount}}
+{{else -}}
+  Empty list
+{{end -}}

--- a/tests/TextTemplate.Tests/TextTemplate.Tests.csproj
+++ b/tests/TextTemplate.Tests/TextTemplate.Tests.csproj
@@ -30,6 +30,12 @@
     <None Include="TestData\full_template_expected.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestData\operations_template.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="TestData\operations_expected.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add `operations_template.txt` and its expected output
- add unit test `OperationsFromFileTests` to verify template functionality
- include test data in output files
- format `operations_template.txt` in multiline style
- fix whitespace in `operations_template.txt` for accurate output

## Testing
- `dotnet test tests/TextTemplate.Tests/TextTemplate.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684b2d8ab8bc832fa10f1df5fa3d8174