### PR TITLE
Add variable assignment support and tests

### DIFF
--- a/tests/TextTemplate.Tests/TemplateEngineTests.cs
+++ b/tests/TextTemplate.Tests/TemplateEngineTests.cs
@@ -670,4 +670,31 @@ Josie";
         });
         result.ShouldBe("- a root;- b root;");
     }
+
+    [Fact]
+    public void VariableDeclaration()
+    {
+        const string tmpl = "{{ $g := \"Hi\" }}{{ $g }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>());
+        result.ShouldBe("Hi");
+    }
+
+    [Fact]
+    public void VariableReassignment()
+    {
+        const string tmpl = "{{ $g := \"Hi\" }}{{ $g = \"Bye\" }}{{ $g }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>());
+        result.ShouldBe("Bye");
+    }
+
+    [Fact]
+    public void RangeLoopWithIndexAndValue()
+    {
+        const string tmpl = "{{ range $i, $v := .Items }}{{ $i }}: {{ $v }};{{ end }}";
+        var result = TemplateEngine.Process(tmpl, new Dictionary<string, object>
+        {
+            ["Items"] = new[] { "a", "b" }
+        });
+        result.ShouldBe("0: a;1: b;");
+    }
 }


### PR DESCRIPTION
## Summary
- preprocess `$var :=` and `$var =` expressions into `assign` calls
- implement `assign` pipeline helper
- resolve `$var` lookups from the current scope
- test variable declaration, reassignment, and range loop index/value

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684da4e60cf8832f9b6fbdfb7feacae8