### PR TITLE
Fix benchmark build by exposing internals

### DIFF
--- a/src/TextTemplate/TextTemplate.csproj
+++ b/src/TextTemplate/TextTemplate.csproj
@@ -27,6 +27,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>TextTemplate.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>TextTemplate.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- expose internal template engine to `TextTemplate.Benchmarks` for building benchmarks

## Testing
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_684e09dd5c88832fb1dfb5faf3d0f369